### PR TITLE
fix: summary hours filters by current year and includes today's session

### DIFF
--- a/src/features/summary/pages/SummaryPage.tsx
+++ b/src/features/summary/pages/SummaryPage.tsx
@@ -9,21 +9,35 @@ import { useMemo, useState } from "react";
 import useSessionsHistory from "src/features/sessions-history/hooks/useSessionsHistory";
 import { Session } from "src/features/session/types/Session";
 import sessionService from "src/features/session/services/sessionService";
+import useTodaySession from "src/features/today-session/hooks/useTodaySession";
 
-function calculateHoursForMonth(history: Array<Session>, month: string) {
+function calculateHoursForMonth(history: Array<Session>, currentSession: Session | null, month: string) {
     const monthIndex = DateTime.fromFormat(month, "LLLL").month;
-    const totalHours = history.reduce((sum, session) => {
+    const currentYear = DateTime.now().year;
+
+    // Calculate from history
+    let totalHours = history.reduce((sum, session) => {
         const sessionDate = DateTime.fromMillis(session.createdTimestamp);
-        if (sessionDate.month === monthIndex) {
-            return sum + (sessionService.getSessionDurationMs(session) || 0) / (1000 * 60 * 60); // Convert ms to hours
+        if (sessionDate.month === monthIndex && sessionDate.year === currentYear) {
+            return sum + (sessionService.getSessionDurationMs(session) || 0) / (1000 * 60 * 60);
         }
         return sum;
     }, 0);
+
+    // Add current session if it matches the selected month and year
+    if (currentSession) {
+        const sessionDate = DateTime.fromMillis(currentSession.createdTimestamp);
+        if (sessionDate.month === monthIndex && sessionDate.year === currentYear) {
+            totalHours += (sessionService.getSessionDurationMs(currentSession) || 0) / (1000 * 60 * 60);
+        }
+    }
+
     return totalHours;
 };
 
 export default function SummaryPage() {
     const sessionsHistory = useSessionsHistory();
+    const { todaySession } = useTodaySession();
 
     const currentMonth = capitalize(DateTime.now().toFormat('LLLL'));
     const [month, setMonth] = useState(currentMonth);
@@ -33,8 +47,8 @@ export default function SummaryPage() {
     );
 
     const selectedMonthHours = useMemo(() => {
-        return calculateHoursForMonth(sessionsHistory, month);
-    }, [month, sessionsHistory]);
+        return calculateHoursForMonth(sessionsHistory, todaySession.session, month);
+    }, [month, sessionsHistory, todaySession.session]);
 
     return (
         <PageLayout>


### PR DESCRIPTION
## Summary
- Summary hours now filters by current year (not all years)
- Includes today's active session in the calculation

## Changes
- Added sessionDate.year === currentYear filter in calculateHoursForMonth
- Added useTodaySession hook to include current session in total hours