### PR TITLE
feat(decimals): change precision from 2 to 3 decimals

### DIFF
--- a/src/features/session-table-modal/hooks/useSessionTableRows.ts
+++ b/src/features/session-table-modal/hooks/useSessionTableRows.ts
@@ -54,7 +54,7 @@ export function useSessionTableRows({
                 ? elapsedTimeMs / 3.6e+6
                 : elapsedTimeMs / 60000;
             // Ceil
-            const elapsedTimeTxt = Math.ceil(elapsedTime * 100) / 100;
+            const elapsedTimeTxt = Math.ceil(elapsedTime * 1000) / 1000;
 
 
             // this is a row

--- a/src/features/summary/pages/SummaryPage.tsx
+++ b/src/features/summary/pages/SummaryPage.tsx
@@ -52,7 +52,7 @@ export default function SummaryPage() {
                 />
 
                 <h1>Summary Page</h1>
-                <p>Total hours for {month}: {selectedMonthHours.toFixed(2)} hours</p>
+                <p>Total hours for {month}: {selectedMonthHours.toFixed(3)} hours</p>
                 <BarChart></BarChart>
             </Container>
         </PageLayout>


### PR DESCRIPTION
## Summary
- Changed decimal precision from 2 to 3 decimals in copied session table
- Also updated summary page to show 3 decimals

## Files Changed
- src/features/session-table-modal/hooks/useSessionTableRows.ts
- src/features/summary/pages/SummaryPage.tsx