### PR TITLE
fix(converter): add 0.6.0 to 0.6.1 pass-through

### DIFF
--- a/src/shared/services/sessionStorageVersionConverter.ts
+++ b/src/shared/services/sessionStorageVersionConverter.ts
@@ -73,6 +73,14 @@ function convertSessionToNext(session: Session, fromVersion: string) {
         }
     }
 
+    // 0.6.0 -> 0.6.1 (no schema changes)
+    if (fromVersion === '0.6.0') {
+        return {
+            value: session,
+            newVersion: '0.6.1'
+        }
+    }
+
     // keep same
     return {
         value: session,


### PR DESCRIPTION
## Summary
- Add pass-through converter for v0.6.0 -> v0.6.1
- No schema changes, just advances version

## Test Plan
- [x] Build passes